### PR TITLE
스프링의 프록시 패토리 빈

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/src/main/java/proxy/TransactionAdvice.java
+++ b/src/main/java/proxy/TransactionAdvice.java
@@ -1,0 +1,28 @@
+package proxy;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+public class TransactionAdvice implements MethodInterceptor {
+    private PlatformTransactionManager transactionManager;
+
+    public void setTransactionManager(PlatformTransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+        try {
+            Object ret = invocation.proceed();
+            transactionManager.commit(status);
+            return ret;
+        } catch (RuntimeException e) {
+            transactionManager.rollback(status);
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -19,11 +19,24 @@
     <property name="userDao" ref="userDao"/>
     <property name="mailSender" ref="mailSender"/>
   </bean>
-  <bean id="userService" class="proxy.TransactionProxyFactoryBean">
+  <bean id="transactionAdvice" class="proxy.TransactionAdvice">
     <property name="transactionManager" ref="transactionManager"/>
+  </bean>
+  <bean id="transactionPointCut" class="org.springframework.aop.support.NameMatchMethodPointcut">
+    <property name="mappedName" value="upgrade*"/>
+  </bean>
+  <bean id="transactionAdvisor" class="org.springframework.aop.support.DefaultPointcutAdvisor">
+    <property name="pointcut" ref="transactionPointCut"/>
+    <property name="advice" ref="transactionAdvice"/>
+  </bean>
+  <!-- 다시 무엇을 해야하는가? 프록시 팩토리 빈에게 타겟을 가르쳐 줘야 한다. 그리고 분리된 Advice 또는 Advisor(Advice + PointCut) 정보를 전달해 주기만 하면 된다. -->
+  <bean id="userService" class="org.springframework.aop.framework.ProxyFactoryBean">
     <property name="target" ref="userServiceImpl"/>
-    <property name="pattern" value="upgradeLevels"/>
-    <property name="serviceInterface" value="service.UserService"/>
+    <property name="interceptorNames">
+      <list>
+        <value>transactionAdvisor</value>
+      </list>
+    </property>
   </bean>
   <bean id="userServiceImpl" class="service.UserServiceImpl">
     <property name="userDao" ref="userDao"/>

--- a/src/test/java/proxy/ProxyTest.java
+++ b/src/test/java/proxy/ProxyTest.java
@@ -2,8 +2,13 @@ package proxy;
 
 import java.lang.reflect.Proxy;
 
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactoryBean;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
 
 public class ProxyTest {
     @Test
@@ -24,5 +29,55 @@ public class ProxyTest {
         Assertions.assertEquals("HELLO TOBY", hello.sayHello("Toby"));
         Assertions.assertEquals("HI TOBY", hello.sayHi("Toby"));
         Assertions.assertEquals("THANK YOU TOBY", hello.sayThankYou("Toby"));
+    }
+
+    /**
+     * 스프링의 다이나믹 프록시 기능(ProxyFactoryBean)을 사용하려면 무엇을 이해하고, 무엇을 해야하는가?
+     * - 우선 ProxyFactoryBean 을 생성해 보자.
+     * - 부가기능을 수행하 Advice를 구현해서 팩토리빈에 주입해 주어야 한다.
+     * - 타겟을 주입해 준다.
+     * - 필요에 따라 타겟의 메서드 중 특정한 메서드만 Advice를 통해 실행되도록 설정할 수 있다.
+     * - 타겟의 인터페이스를 받지 않는다. 스프링의 ProxyFactoryBean 내부에서 타겟이 구현한 모든 인터페이스를 알아내서 나이나믹
+     * - getObject()를 통해 다이나믹 프록시를 얻으면 되고, 프록시를 타겟 처럼 사용하면 된다.
+     */
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void proxyFactoryBean() {
+        ProxyFactoryBean factoryBean = new ProxyFactoryBean();
+        factoryBean.setTarget(new HelloTarget());
+        factoryBean.addAdvice(new UpperCaseAdvice());
+        Hello hello = (Hello) factoryBean.getObject();
+
+        Assertions.assertEquals("HELLO TOBY", hello.sayHello("Toby"));
+        Assertions.assertEquals("HI TOBY", hello.sayHi("Toby"));
+        Assertions.assertEquals("THANK YOU TOBY", hello.sayThankYou("Toby"));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void pointCutAdvisoer() {
+        ProxyFactoryBean factoryBean = new ProxyFactoryBean();
+        factoryBean.setTarget(new HelloTarget());
+
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        pointcut.setMappedName("sayH*");
+        factoryBean.addAdvisor(new DefaultPointcutAdvisor(pointcut, new UpperCaseAdvice()));
+        Hello hello = (Hello) factoryBean.getObject();
+
+        Assertions.assertEquals("HELLO TOBY", hello.sayHello("Toby"));
+        Assertions.assertEquals("HI TOBY", hello.sayHi("Toby"));
+        Assertions.assertEquals("Thank You Toby", hello.sayThankYou("Toby"));
+    }
+
+    // 템플릿/콜백 패턴에서 콜백 메서드 객체 역할을 한다.
+    static class UpperCaseAdvice implements MethodInterceptor {
+
+        // MethodInvocation
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            String ret = (String) invocation.proceed();
+            assert ret != null;
+            return ret.toUpperCase();
+        }
     }
 }

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -1,6 +1,13 @@
 package service;
 
-import dao.UserDao;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,6 +15,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.mail.MailSender;
@@ -16,17 +24,10 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import dao.UserDao;
 import pojo.User;
-import proxy.TransactionProxyFactoryBean;
 import service.mock.MockMailSender;
-
-import java.io.Serial;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-
-import static org.mockito.ArgumentMatchers.any;
 
 @RunWith(SpringJUnit4ClassRunner.class) // 스프링의 테스트 컨텍스트 프레임워크의 JUnit 확장기능 지정
 @ContextConfiguration(locations="/applicationContext.xml") // 테스트 컨텍스트가 자동으로 만들어줄 애플리케이션 컨텍스트의 위치 지정
@@ -157,11 +158,11 @@ public class UserServiceTest {
         policy.setUserDao(userDao);
         policy.setMailSender(mailSender);
 
-        UserServiceImpl userServiceImpl = context.getBean("userServiceImpl", UserServiceImpl.class);
-        userServiceImpl.setUserLevelUpgradePolicy(policy);
+        UserServiceImpl testUserServiceImpl = context.getBean("userServiceImpl", UserServiceImpl.class);
+        testUserServiceImpl.setUserLevelUpgradePolicy(policy);
 
-        TransactionProxyFactoryBean factoryBean = context.getBean("&userService", TransactionProxyFactoryBean.class);
-        factoryBean.setTarget(userServiceImpl);
+        ProxyFactoryBean factoryBean = context.getBean("&userService", ProxyFactoryBean.class);
+        factoryBean.setTarget(testUserServiceImpl);
         UserService testUserService = (UserService) factoryBean.getObject();
 
         users.forEach(user -> userDao.add(user));


### PR DESCRIPTION
- 타겟 객체와 메서드 선정 코드가 InvocationHandler에서 제거하고 순수하게 부가기능에만 집중하는 디자인을 위해 TransactionAdvice 개념 등장
- 타겟 객체 정보는 MethodInvocation 객체에 추상화되어 MethodInterceptor(Advice)에 전달된다.
- 타겟 객체의 메서드 선정 코드는 PointCut 인터페이스를 구현한 객체를 통해 추상화 된다. 
- ProxyFactoryBean에는 MethodInterceptor(Advice)와 PointCut 구현 객체를 포함하는 Advisor를 DI받아 처리한다. 